### PR TITLE
Fix packaging version check

### DIFF
--- a/changelog/000.bugfix.md
+++ b/changelog/000.bugfix.md
@@ -1,0 +1,1 @@
+Fixed validation code to handle `packaging` versions >=21 by replacing the deprecated `LegacyVersion` check with handling of `InvalidVersion` exceptions.

--- a/rasa/shared/utils/validation.py
+++ b/rasa/shared/utils/validation.py
@@ -3,7 +3,7 @@ import os
 from typing import Text, Dict, List, Optional, Any
 
 from packaging import version
-from packaging.version import LegacyVersion
+from packaging.version import InvalidVersion
 from pykwalify.errors import SchemaError
 
 from ruamel.yaml.constructor import DuplicateKeyError
@@ -249,9 +249,6 @@ def validate_training_data_format_version(
         parsed_version = version.parse(version_value)
         latest_version = version.parse(LATEST_TRAINING_DATA_FORMAT_VERSION)
 
-        if isinstance(parsed_version, LegacyVersion):
-            raise TypeError
-
         if parsed_version < latest_version:
             rasa.shared.utils.io.raise_warning(
                 f"Training data file {filename} has a lower "
@@ -268,7 +265,7 @@ def validate_training_data_format_version(
 
             return True
 
-    except TypeError:
+    except (TypeError, InvalidVersion):
         rasa.shared.utils.io.raise_warning(
             f"Training data file {filename} must specify "
             f"'{KEY_TRAINING_DATA_FORMAT_VERSION}' as string, for example:\n"


### PR DESCRIPTION
## Summary
- handle `InvalidVersion` exceptions in YAML validation instead of using removed `LegacyVersion`
- add changelog entry

## Testing
- `python - <<'EOF'
import rasa.utils.common

def test_override_defaults():
    defaults = {"nested-dict": {"key1": "value1", "key2": "value2"}}
    custom = {"nested-dict": {"key2": "override-value2"}}
    updated_config = rasa.utils.common.override_defaults(defaults, custom)
    expected_config = {"nested-dict": {"key1": "value1", "key2": "override-value2"}}
    assert updated_config == expected_config

test_override_defaults()
print('OK')
EOF

------
https://chatgpt.com/codex/tasks/task_e_6846f2127a7c832b85dc4c074f80a278

## Summary by Sourcery

Fix training data format version validation to support newer packaging versions by catching InvalidVersion exceptions instead of relying on the deprecated LegacyVersion check

Bug Fixes:
- Replace LegacyVersion type check with InvalidVersion exception handling in validate_training_data_format_version

Documentation:
- Add changelog entry for the packaging version validation fix